### PR TITLE
Fix the error that callback will be called 2 times

### DIFF
--- a/lib/imagesize.js
+++ b/lib/imagesize.js
@@ -282,7 +282,8 @@ function imagesize(stream, cb) {
   };
 
   var handleEnd = function () {
-    done('invalid');
+//    FIXME: I'm not sure why we need to re turn an 'invalid' error here. This cause the error that cb will be called 2 times
+//    done('invalid');
   };
 
   var handleData = function (data) {


### PR DESCRIPTION
I'm not sure why we need to re turn an 'invalid' error when stream end. This cause the error that cb will be called 2 times
